### PR TITLE
Drop core/its due to core refactoring

### DIFF
--- a/aggregator/core/pom.xml
+++ b/aggregator/core/pom.xml
@@ -35,7 +35,6 @@ under the License.
     <module>../../../core/build-cache</module>
     <module>../../../core/maven</module>
     <module>../../../core/mvnd</module>
-    <module>../../../core/its</module>
     <module>../../../core/resolver</module>
     <module>../../../core/resolver-ant-tasks</module>
     <module>../../../core/wrapper</module>


### PR DESCRIPTION
Fix aggregator build according to vanished core ITs, cf. apache/maven-integration-testing#401.