### PR TITLE
Cleanup repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repo sync
 repo start master --all
 ```
 
-Resulting directory tree looks like:
+The resulting directory tree looks like:
 
 ```
 |-- core
@@ -32,12 +32,18 @@ Resulting directory tree looks like:
 |   |-- site
 |   |-- sitetools
 |   `-- tools
+|       |-- converter
+|       |-- doxia-book-maven-plugin
+|       |-- doxia-book-renderer
+|       `-- linkcheck
 |-- misc
 |   |-- archetypes
 |   |-- dist-tool
 |   |-- gh-actions-shared
 |   |-- indexer
 |   |-- jenkins
+|   |   |-- env
+|   |   `-- lib
 |   |-- plugin-testing
 |   |-- pom
 |   |   |-- apache
@@ -48,13 +54,13 @@ Resulting directory tree looks like:
 |   |   `-- fluido
 |   `-- wagon
 |-- plexus
+|   |-- .github
 |   |-- classworlds
 |   |-- codehaus-plexus.github.io
 |   |-- components
 |   |   |-- archiver
 |   |   |-- cipher
 |   |   |-- compiler
-|   |   |-- digest
 |   |   |-- i18n
 |   |   |-- interactivity
 |   |   |-- interpolation
@@ -62,12 +68,13 @@ Resulting directory tree looks like:
 |   |   |-- languages
 |   |   |-- resources
 |   |   |-- sec-dispatcher
-|   |   |-- testing
 |   |   `-- velocity
 |   |-- modello
 |   |-- plexus-containers
 |   |-- pom
+|   |   `-- plexus
 |   |-- utils
+|   |-- testing
 |   `-- xml
 |-- plugins
 |   |-- core
@@ -123,7 +130,6 @@ Resulting directory tree looks like:
 |       `-- scm
 |-- shared
 |   |-- archiver
-|   |-- artifact-transfer
 |   |-- common-artifact-filters
 |   |-- dependency-analyzer
 |   |-- dependency-tree
@@ -132,7 +138,6 @@ Resulting directory tree looks like:
 |   |-- invoker
 |   |-- jarsigner
 |   |-- mapping
-|   |-- project-utils
 |   |-- reporting-api
 |   |-- reporting-exec
 |   |-- reporting-impl
@@ -148,11 +153,16 @@ Resulting directory tree looks like:
 |-- site
 |-- sources
 |   `-- aggregator
-|-- studies
-`-- svn
-    |-- doxia-ide
-    |-- repository-tools
-    `-- sandbox
+`-- studies
+    |-- consumer-pom
+    |-- master
+    |-- maven-basedir-filesystem
+    |-- maven-ci-extension
+    |-- maven-default-plugins
+    |-- maven-eventsound-extension
+    `-- maven-extension-demo
+
+
 ```
 
 Then simply use the content in this tree with normal `git` commands.

--- a/aggregator/plexus/components/pom.xml
+++ b/aggregator/plexus/components/pom.xml
@@ -32,19 +32,16 @@ under the License.
 
   <name>Aggregator POM for Plexus Components</name>
   <modules>
+    <module>../../../../plexus/components/archiver</module>
     <module>../../../../plexus/components/cipher</module>
     <module>../../../../plexus/components/compiler</module>
     <module>../../../../plexus/components/i18n</module>
-    <module>../../../../plexus/components/interpolation</module>
-    <module>../../../../plexus/components/languages</module>
-    <module>../../../../plexus/components/sec-dispatcher</module>
-    <module>../../../../plexus/components/archiver</module>
-    <!--<module>../../../../plexus/components/cli</module>-->
-    <module>../../../../plexus/components/digest</module>
     <module>../../../../plexus/components/interactivity</module>
+    <module>../../../../plexus/components/interpolation</module>
     <module>../../../../plexus/components/io</module>
+    <module>../../../../plexus/components/languages</module>
     <module>../../../../plexus/components/resources</module>
-    <!--module>../../../plexus/components/swizzle</module-->
+    <module>../../../../plexus/components/sec-dispatcher</module>
     <module>../../../../plexus/components/velocity</module>
   </modules>
 </project>

--- a/aggregator/plexus/pom.xml
+++ b/aggregator/plexus/pom.xml
@@ -36,8 +36,6 @@ under the License.
     <module>../../../plexus/codehaus-plexus.github.io</module>
     <module>components</module>
     <module>../../../plexus/modello</module>
-    <module>../../../plexus/plexus-containers</module>
-    <module>../../../plexus/pom/components</module>
     <module>../../../plexus/pom/plexus</module>
     <module>../../../plexus/utils</module>
     <module>../../../plexus/xml</module>

--- a/aggregator/plexus/pom.xml
+++ b/aggregator/plexus/pom.xml
@@ -32,11 +32,12 @@ under the License.
 
   <name>Aggregator POM for Plexus</name>
   <modules>
-    <module>../../../plexus/classworlds</module>
     <module>../../../plexus/codehaus-plexus.github.io</module>
-    <module>components</module>
     <module>../../../plexus/modello</module>
+    <module>../../../plexus/classworlds</module>
+    <module>components</module>
     <module>../../../plexus/pom/plexus</module>
+    <module>../../../plexus/testing</module>
     <module>../../../plexus/utils</module>
     <module>../../../plexus/xml</module>
   </modules>

--- a/default.xml
+++ b/default.xml
@@ -143,9 +143,7 @@
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />
   <project path='plexus/components/archiver'                name='plexus-archiver.git'           remote='plexus' />
   <project path='plexus/components/cipher'                  name='plexus-cipher.git'             remote='plexus' />
-  <project path='plexus/components/cli'                     name='plexus-cli.git'                remote='plexus' />
   <project path='plexus/components/compiler'                name='plexus-compiler.git'           remote='plexus' />
-  <project path='plexus/components/digest'                  name='plexus-digest.git'             remote='plexus' />
   <project path='plexus/components/i18n'                    name='plexus-i18n.git'               remote='plexus' />
   <project path='plexus/components/interactivity'           name='plexus-interactivity.git'      remote='plexus' />
   <project path='plexus/components/interpolation'           name='plexus-interpolation.git'      remote='plexus' />

--- a/default.xml
+++ b/default.xml
@@ -137,6 +137,7 @@
   <project path='studies/maven-eventsound-extension'        name='maven-studies.git' revision="maven-eventsound-extension" />
   <project path='studies/maven-extension-demo'              name='maven-studies.git' revision="maven-extension-demo" />
 
+  <project path='plexus/.github'                            name='.github.git'                   remote='plexus' />
   <project path='plexus/codehaus-plexus.github.io'          name='codehaus-plexus.github.io.git' remote='plexus' revision='source' />
   <project path='plexus/modello'                            name='modello.git'                   remote='plexus' />
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />

--- a/default.xml
+++ b/default.xml
@@ -88,7 +88,6 @@
   <project path='plugins/tools/maven-toolchains-plugin'     name='maven-toolchains-plugin.git' />
 
   <project path='shared/archiver'                           name='maven-archiver.git' />
-  <project path='shared/artifact-transfer'                  name='maven-artifact-transfer.git' />
   <project path='shared/common-artifact-filters'            name='maven-common-artifact-filters.git' />
   <project path='shared/dependency-analyzer'                name='maven-dependency-analyzer.git' />
   <project path='shared/dependency-tree'                    name='maven-dependency-tree.git' />
@@ -97,7 +96,6 @@
   <project path='shared/invoker'                            name='maven-invoker.git' />
   <project path='shared/jarsigner'                          name='maven-jarsigner.git' />
   <project path='shared/mapping'                            name='maven-mapping.git' />
-  <project path='shared/project-utils'                      name='maven-project-utils.git' />
   <project path='shared/reporting-api'                      name='maven-reporting-api.git' />
   <project path='shared/reporting-exec'                     name='maven-reporting-exec.git' />
   <project path='shared/reporting-impl'                     name='maven-reporting-impl.git' />
@@ -139,10 +137,6 @@
   <project path='studies/maven-eventsound-extension'        name='maven-studies.git' revision="maven-eventsound-extension" />
   <project path='studies/maven-extension-demo'              name='maven-studies.git' revision="maven-extension-demo" />
 
-  <project path='svn/repository-tools'                      name='maven-repository-tools.git'    revision='trunk' />
-  <project path='svn/sandbox'                               name='maven-sandbox.git'             revision='trunk' />
-  <project path='svn/doxia-ide'                             name='maven-doxia-ide.git'           revision='trunk' />
-
   <project path='plexus/codehaus-plexus.github.io'          name='codehaus-plexus.github.io.git' remote='plexus' revision='source' />
   <project path='plexus/modello'                            name='modello.git'                   remote='plexus' />
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />
@@ -158,10 +152,7 @@
   <project path='plexus/components/languages'               name='plexus-languages.git'          remote='plexus' />
   <project path='plexus/components/resources'               name='plexus-resources.git'          remote='plexus' />
   <project path='plexus/components/sec-dispatcher'          name='plexus-sec-dispatcher.git'     remote='plexus' />
-  <project path='plexus/components/swizzle'                 name='plexus-swizzle.git'            remote='plexus' />
   <project path='plexus/components/velocity'                name='plexus-velocity.git'           remote='plexus' />
-  <project path='plexus/plexus-containers'                  name='plexus-containers.git'         remote='plexus' />
-  <project path='plexus/pom/components'                     name='plexus-components.git'         remote='plexus' />
   <project path='plexus/pom/plexus'                         name='plexus-pom.git'                remote='plexus' />
   <project path='plexus/testing'                            name='plexus-testing.git'            remote='plexus' />
   <project path='plexus/utils'                              name='plexus-utils.git'              remote='plexus' />


### PR DESCRIPTION
Some projects are (already) archived or even no longer used by the Apache team.
Therefore, they are not needed when checking out the Maven sources.
Instead we add https://github.com/codehaus-plexus/.github as part of the sources (as it contains common GitHub actions for Plexus components).

This change is a late result of support-and-care/maven-support-and-care#77.