### PR TITLE
Add missing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ Resulting directory tree looks like:
 |   |-- site
 |   |-- sitetools
 |   `-- tools
+|       |-- converter
+|       |-- doxia-book-maven-plugin
+|       |-- doxia-book-renderer
+|       `-- linkcheck
 |-- misc
 |   |-- archetypes
 |   |-- dist-tool
 |   |-- gh-actions-shared
 |   |-- indexer
 |   |-- jenkins
+|   |   |-- env
+|   |   `-- lib
 |   |-- plugin-testing
 |   |-- pom
 |   |   |-- apache
@@ -69,7 +75,9 @@ Resulting directory tree looks like:
 |   |-- modello
 |   |-- plexus-containers
 |   |-- pom
+|   |   `-- plexus
 |   |-- utils
+|   |-- testing
 |   `-- xml
 |-- plugins
 |   |-- core
@@ -150,11 +158,14 @@ Resulting directory tree looks like:
 |-- site
 |-- sources
 |   `-- aggregator
-|-- studies
-`-- svn
-    |-- doxia-ide
-    |-- repository-tools
-    `-- sandbox
+`-- studies
+    |-- consumer-pom
+    |-- master
+    |-- maven-basedir-filesystem
+    |-- maven-ci-extension
+    |-- maven-default-plugins
+    |-- maven-eventsound-extension
+    `-- maven-extension-demo
 ```
 
 Then simply use the content in this tree with normal `git` commands.

--- a/aggregator/plexus/pom.xml
+++ b/aggregator/plexus/pom.xml
@@ -39,6 +39,7 @@ under the License.
     <module>../../../plexus/plexus-containers</module>
     <module>../../../plexus/pom/components</module>
     <module>../../../plexus/pom/plexus</module>
+    <module>../../../plexus/testing</module>
     <module>../../../plexus/utils</module>
     <module>../../../plexus/xml</module>
   </modules>


### PR DESCRIPTION
These modules are available/used but missing in the docs or even in the (aggregator) build.

Note, this replaces #18 (partially).