### PR TITLE
Drop outdated components

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ Resulting directory tree looks like:
 |   |-- codehaus-plexus.github.io
 |   |-- components
 |   |   |-- archiver
-|   |   |-- cipher
 |   |   |-- compiler
-|   |   |-- digest
 |   |   |-- i18n
 |   |   |-- interactivity
 |   |   |-- interpolation
@@ -134,7 +132,6 @@ Resulting directory tree looks like:
 |       `-- scm
 |-- shared
 |   |-- archiver
-|   |-- artifact-transfer
 |   |-- common-artifact-filters
 |   |-- dependency-analyzer
 |   |-- dependency-tree
@@ -143,7 +140,6 @@ Resulting directory tree looks like:
 |   |-- invoker
 |   |-- jarsigner
 |   |-- mapping
-|   |-- project-utils
 |   |-- reporting-api
 |   |-- reporting-exec
 |   |-- reporting-impl

--- a/aggregator/plexus/components/pom.xml
+++ b/aggregator/plexus/components/pom.xml
@@ -32,19 +32,15 @@ under the License.
 
   <name>Aggregator POM for Plexus Components</name>
   <modules>
-    <module>../../../../plexus/components/cipher</module>
     <module>../../../../plexus/components/compiler</module>
     <module>../../../../plexus/components/i18n</module>
     <module>../../../../plexus/components/interpolation</module>
     <module>../../../../plexus/components/languages</module>
     <module>../../../../plexus/components/sec-dispatcher</module>
     <module>../../../../plexus/components/archiver</module>
-    <!--<module>../../../../plexus/components/cli</module>-->
-    <module>../../../../plexus/components/digest</module>
     <module>../../../../plexus/components/interactivity</module>
     <module>../../../../plexus/components/io</module>
     <module>../../../../plexus/components/resources</module>
-    <!--module>../../../plexus/components/swizzle</module-->
     <module>../../../../plexus/components/velocity</module>
   </modules>
 </project>

--- a/aggregator/plexus/pom.xml
+++ b/aggregator/plexus/pom.xml
@@ -36,8 +36,6 @@ under the License.
     <module>../../../plexus/codehaus-plexus.github.io</module>
     <module>components</module>
     <module>../../../plexus/modello</module>
-    <module>../../../plexus/plexus-containers</module>
-    <module>../../../plexus/pom/components</module>
     <module>../../../plexus/pom/plexus</module>
     <module>../../../plexus/testing</module>
     <module>../../../plexus/utils</module>

--- a/default.xml
+++ b/default.xml
@@ -90,7 +90,6 @@
   <project path='plugins/tools/maven-toolchains-plugin'     name='maven-toolchains-plugin.git' />
 
   <project path='shared/archiver'                           name='maven-archiver.git' />
-  <project path='shared/artifact-transfer'                  name='maven-artifact-transfer.git' />
   <project path='shared/common-artifact-filters'            name='maven-common-artifact-filters.git' />
   <project path='shared/dependency-analyzer'                name='maven-dependency-analyzer.git' />
   <project path='shared/dependency-tree'                    name='maven-dependency-tree.git' />
@@ -99,7 +98,6 @@
   <project path='shared/invoker'                            name='maven-invoker.git' />
   <project path='shared/jarsigner'                          name='maven-jarsigner.git' />
   <project path='shared/mapping'                            name='maven-mapping.git' />
-  <project path='shared/project-utils'                      name='maven-project-utils.git' />
   <project path='shared/reporting-api'                      name='maven-reporting-api.git' />
   <project path='shared/reporting-exec'                     name='maven-reporting-exec.git' />
   <project path='shared/reporting-impl'                     name='maven-reporting-impl.git' />
@@ -149,10 +147,7 @@
   <project path='plexus/modello'                            name='modello.git'                   remote='plexus' />
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />
   <project path='plexus/components/archiver'                name='plexus-archiver.git'           remote='plexus' />
-  <project path='plexus/components/cipher'                  name='plexus-cipher.git'             remote='plexus' />
-  <project path='plexus/components/cli'                     name='plexus-cli.git'                remote='plexus' />
   <project path='plexus/components/compiler'                name='plexus-compiler.git'           remote='plexus' />
-  <project path='plexus/components/digest'                  name='plexus-digest.git'             remote='plexus' />
   <project path='plexus/components/i18n'                    name='plexus-i18n.git'               remote='plexus' />
   <project path='plexus/components/interactivity'           name='plexus-interactivity.git'      remote='plexus' />
   <project path='plexus/components/interpolation'           name='plexus-interpolation.git'      remote='plexus' />
@@ -160,10 +155,7 @@
   <project path='plexus/components/languages'               name='plexus-languages.git'          remote='plexus' />
   <project path='plexus/components/resources'               name='plexus-resources.git'          remote='plexus' />
   <project path='plexus/components/sec-dispatcher'          name='plexus-sec-dispatcher.git'     remote='plexus' />
-  <project path='plexus/components/swizzle'                 name='plexus-swizzle.git'            remote='plexus' />
   <project path='plexus/components/velocity'                name='plexus-velocity.git'           remote='plexus' />
-  <project path='plexus/plexus-containers'                  name='plexus-containers.git'         remote='plexus' />
-  <project path='plexus/pom/components'                     name='plexus-components.git'         remote='plexus' />
   <project path='plexus/pom/plexus'                         name='plexus-pom.git'                remote='plexus' />
   <project path='plexus/testing'                            name='plexus-testing.git'            remote='plexus' />
   <project path='plexus/utils'                              name='plexus-utils.git'              remote='plexus' />

--- a/retired.xml
+++ b/retired.xml
@@ -33,8 +33,18 @@
   <project path='plugins/tools/maven-repository-plugin'     name='maven-repository-plugin.git' />
 
   <project path='shared/artifact-resolver'                  name='maven-artifact-resolver.git' /> 
+  <project path='shared/artifact-transfer'                  name='maven-artifact-transfer.git' />
   <project path='shared/downloader'                         name='maven-downloader.git' />
   <project path='shared/osgi'                               name='maven-osgi.git' />
+  <project path='shared/project-utils'                      name='maven-project-utils.git' />
   <project path='shared/repository-builder'                 name='maven-repository-builder.git' />
   <project path='shared/runtime'                            name='maven-runtime.git' />
+
+  <project path='plexus/components/cipher'                  name='plexus-cipher.git'             remote='plexus' />
+  <project path='plexus/components/cli'                     name='plexus-cli.git'                remote='plexus' />
+  <project path='plexus/components/digest'                  name='plexus-digest.git'             remote='plexus' />
+  <project path='plexus/components/swizzle'                 name='plexus-swizzle.git'            remote='plexus' />
+  <project path='plexus/plexus-containers'                  name='plexus-containers.git'         remote='plexus' />
+  <project path='plexus/pom/components'                     name='plexus-components.git'         remote='plexus' />
+
 </manifest>


### PR DESCRIPTION
These components are either already archived or otherwise outdated, e.g.,
- rely on Java 7
- were already dropped from frequent or even aggregator builds.

Note that some of them should be even archived on GitHub as they are no longer maintained.

Detected in the course of support-and-care/maven-support-and-care#77. Cf. https://github.com/support-and-care/maven-support-and-care/blob/main/src/docs/epics/77-maven-due-diligence/index.adoc#archived-components

Note,
- This replaces #18 (partially).
- This may lead to conflicts with #22 (in the end of the README.md): Let me rebase the PR as soon as #22 is merged.