### PR TITLE
create core/3.x for Maven 3-related modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Resulting directory tree looks like:
 ```
 |-- core
 |   |-- build-cache
-|   |-- its
 |   |-- maven
-|   |-- maven-3
 |   |-- mvnd
-|   |-- mvnd-1
 |   |-- resolver
-|   |-- resolver-1
 |   |-- resolver-ant-tasks
-|   `-- wrapper
+|   |-- wrapper
+|   `-- 3.x
+|       |-- its
+|       |-- maven-3
+|       |-- mvnd-1
+|       `-- resolver-1
 |-- doxia
 |   |-- doxia
 |   |-- site

--- a/aggregator/core/pom.xml
+++ b/aggregator/core/pom.xml
@@ -38,5 +38,6 @@ under the License.
     <module>../../../core/resolver</module>
     <module>../../../core/resolver-ant-tasks</module>
     <module>../../../core/wrapper</module>
+    <!--module>3.x</module-->
   </modules>
 </project>

--- a/default.xml
+++ b/default.xml
@@ -29,14 +29,14 @@
 
   <project path='core/build-cache'                          name='maven-build-cache-extension.git' />
   <project path='core/maven'                                name='maven.git' />
-  <project path='core/maven-3'                              name='maven.git' revision="maven-3.9.x" />
   <project path='core/mvnd'                                 name='maven-mvnd.git' />
-  <project path='core/mvnd-1'                               name='maven-mvnd.git' revision="mvnd-1.x" />
-  <project path='core/its'                                  name='maven-integration-testing.git' />
   <project path='core/resolver'                             name='maven-resolver.git' />
-  <project path='core/resolver-1'                           name='maven-resolver.git' revision="maven-resolver-1.9.x" />
   <project path='core/resolver-ant-tasks'                   name='maven-resolver-ant-tasks.git' />
   <project path='core/wrapper'                              name='maven-wrapper.git' />
+  <project path='core/3.x/maven-3'                          name='maven.git' revision="maven-3.9.x" />
+  <project path='core/3.x/mvnd-1'                           name='maven-mvnd.git' revision="mvnd-1.x" />
+  <project path='core/3.x/resolver-1'                       name='maven-resolver.git' revision="maven-resolver-1.9.x" />
+  <project path='core/3.x/its-3'                            name='maven-integration-testing.git' revision="maven-3.9.x" />
 
   <project path='plugins/core/maven-clean-plugin'           name='maven-clean-plugin.git' />
   <project path='plugins/core/maven-compiler-plugin'        name='maven-compiler-plugin.git' />


### PR DESCRIPTION
core its specifically are now Maven 3 specific, as they have been merged in Maven core Git repo for 4
https://github.com/apache/maven-integration-testing