### PR TITLE
Change sisu's tracking branch from master to main (closes #36)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -172,5 +172,5 @@
   <project path='plexus/utils'                              name='plexus-utils.git'              remote='plexus' />
   <project path='plexus/xml'                                name='plexus-xml.git'                remote='plexus' />
 
-  <project path='sisu/sisu-project'                         name='sisu-project.git'              remote='sisu' />
+  <project path='sisu/sisu-project'                         name='sisu-project.git'              remote='sisu' revision='main' />
 </manifest>

--- a/retired.xml
+++ b/retired.xml
@@ -22,7 +22,6 @@
   <remote name='origin'  fetch='https://github.com/apache' />
   <remote name='plexus'  fetch='https://github.com/codehaus-plexus' />
   <remote name='svn2git' fetch='https://github.com/apache' />
-  <remote name='sisu'    fetch='https://github.com/eclipse-sisu' />
   <default revision='master' remote='origin' sync-j='8' />
 
   <project path='plugins/reporting/maven-docck-plugin'      name='maven-docck-plugin.git' />


### PR DESCRIPTION
 Since last 5 years Sisu development happened on `main` and not the `master` branch. Moreover, the other day after  releasing Sisu 1.0.0, we cleaned up repo and dropped `master` branch to stop obvious confusion. But, this move broke `repo` command, as refd branch does not exists anymore.

Fixes #36 