### PR TITLE
Exclude obsolete modules from Aggregator

### DIFF
--- a/aggregator/doxia/pom.xml
+++ b/aggregator/doxia/pom.xml
@@ -37,6 +37,5 @@ under the License.
     <module>../../../doxia/sitetools</module>
     <module>../../../doxia/tools/doxia-book-maven-plugin</module>
     <module>../../../doxia/tools/converter</module>
-    <module>../../../doxia/tools/linkcheck</module>
   </modules>
 </project>

--- a/aggregator/misc/pom.xml
+++ b/aggregator/misc/pom.xml
@@ -36,7 +36,6 @@ under the License.
     <module>../../../misc/dist-tool</module>
     <module>../../../misc/indexer</module>
     <!-- not a module: jenkins -->
-    <module>../../../misc/plugin-testing</module>
     <module>../../../misc/pom/apache</module>
     <module>../../../misc/pom/apache-resources</module>
     <module>../../../misc/pom/maven</module>


### PR DESCRIPTION
```
$ mvn --file sources/aggregator/pom.xml validate
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Child module /sources/apache/maven/sources/aggregator/doxia/../../../doxia/tools/linkcheck of /sources/apache/maven/sources/aggregator/doxia/pom.xml does not exist @
[ERROR] Child module /sources/apache/maven/sources/aggregator/misc/../../../misc/plugin-testing/pom.xml of /sources/apache/maven/sources/aggregator/misc/pom.xml does not exist @
 @
[ERROR] The build could not read 2 projects -> [Help 1]
[ERROR]
[ERROR]   The project org.apache.maven.aggregator:doxia:1.0-SNAPSHOT (/sources/apache/maven/sources/aggregator/doxia/pom.xml) has 1 error
[ERROR]     Child module /sources/apache/maven/sources/aggregator/doxia/../../../doxia/tools/linkcheck of /sources/apache/maven/sources/aggregator/doxia/pom.xml does not exist
[ERROR]
[ERROR]   The project org.apache.maven.aggregator:misc:1.0-SNAPSHOT (/sources/apache/maven/sources/aggregator/misc/pom.xml) has 1 error
[ERROR]     Child module /sources/apache/maven/sources/aggregator/misc/../../../misc/plugin-testing/pom.xml of /sources/apache/maven/sources/aggregator/misc/pom.xml does not exist
```

- The Testing Framework is now part of Maven Core.
- Doxia LinkCheck library has been retired and is no longer maintained.