### PR TITLE
The maven-executor has only main branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -131,7 +131,7 @@
   <project path='misc/pom/apache-resources'                 name='maven-apache-resources.git' />
   <project path='misc/skins/fluido'                         name='maven-fluido-skin.git' />
   <project path='misc/dist-tool'                            name='maven-dist-tool.git' />
-  <project path='misc/executor'                             name='maven-executor.git' revision="executor-1.x" />
+  <project path='misc/executor'                             name='maven-executor.git' revision="main" />
   <project path='misc/gh-actions-shared/main'               name='maven-gh-actions-shared.git' revision="main" />
   <project path='misc/gh-actions-shared/v4'                 name='maven-gh-actions-shared.git' revision="v4" />
   <project path='misc/jenkins/env'                          name='maven-jenkins-env.git' />


### PR DESCRIPTION
The maven-executor was "toned down" and now has only main branch.