### PR TITLE
Add plexus GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Resulting directory tree looks like:
 |   |   `-- fluido
 |   `-- wagon
 |-- plexus
+|   |-- .github
 |   |-- classworlds
 |   |-- codehaus-plexus.github.io
 |   |-- components

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Resulting directory tree looks like:
 |   |   `-- fluido
 |   `-- wagon
 |-- plexus
-|   |-- .github
+|   |-- github
 |   |-- classworlds
 |   |-- codehaus-plexus.github.io
 |   |-- components

--- a/default.xml
+++ b/default.xml
@@ -155,6 +155,7 @@
   <project path='svn/doxia-ide'                             name='maven-doxia-ide.git'           revision='trunk' />
 
   <project path='plexus/codehaus-plexus.github.io'          name='codehaus-plexus.github.io.git' remote='plexus' revision='source' />
+  <project path='plexus/.github'                            name='.github.git'                   remote='plexus' />
   <project path='plexus/modello'                            name='modello.git'                   remote='plexus' />
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />
   <project path='plexus/components/archiver'                name='plexus-archiver.git'           remote='plexus' />

--- a/default.xml
+++ b/default.xml
@@ -155,7 +155,7 @@
   <project path='svn/doxia-ide'                             name='maven-doxia-ide.git'           revision='trunk' />
 
   <project path='plexus/codehaus-plexus.github.io'          name='codehaus-plexus.github.io.git' remote='plexus' revision='source' />
-  <project path='plexus/.github'                            name='.github.git'                   remote='plexus' />
+  <project path='plexus/github'                             name='.github.git'                   remote='plexus' />
   <project path='plexus/modello'                            name='modello.git'                   remote='plexus' />
   <project path='plexus/classworlds'                        name='plexus-classworlds.git'        remote='plexus' />
   <project path='plexus/components/archiver'                name='plexus-archiver.git'           remote='plexus' />


### PR DESCRIPTION
Adds the Codehaus Plexus shared `.github` repository to the manifest, as
it is used across Plexus projects and handy to have at hand when working
on GH workflows.

This supersedes #21, which was raised from a fork I no longer have write
access to and could therefore no longer be updated. The branch has been
rebased onto the current `master`.

It also addresses @hboutemy's review on #21: the local checkout path uses
the visible name `github` instead of the hidden `.github` (commit
43cd665). The remote repository name (`.github.git`) is unchanged.