### PR TITLE
Check out the v5 branch of maven-gh-actions-shared

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -133,7 +133,7 @@
   <project path='misc/dist-tool'                            name='maven-dist-tool.git' />
   <project path='misc/executor'                             name='maven-executor.git' revision="main" />
   <project path='misc/gh-actions-shared/main'               name='maven-gh-actions-shared.git' revision="main" />
-  <project path='misc/gh-actions-shared/v4'                 name='maven-gh-actions-shared.git' revision="v4" />
+  <project path='misc/gh-actions-shared/v5'                 name='maven-gh-actions-shared.git' revision="v5" />
   <project path='misc/jenkins/env'                          name='maven-jenkins-env.git' />
   <project path='misc/jenkins/lib'                          name='maven-jenkins-lib.git' />
   <project path='misc/indexer'                              name='maven-indexer.git' />


### PR DESCRIPTION
The manifest still fetches the `v4` branch of `maven-gh-actions-shared`, but the repositories have moved on. Of the 93 workflows in a full checkout that call the shared `maven-verify`, **88 pin `@v5`** and only five still pin `@v4`:

- `maven-checkstyle-plugin`
- `maven-reporting-api`
- `maven-shared-jar`
- `maven-doxia-converter`
- `maven-wagon`

So anyone reading the shared workflow out of the checkout — to work out why a build behaves the way it does — is reading a version that almost nothing uses.

This points the project at `v5` and moves its path to match. The `main` branch entry is unchanged.

Note for anyone syncing an existing checkout: `repo sync` will create `misc/gh-actions-shared/v5` but will not remove the old `misc/gh-actions-shared/v4` working directory, which can be deleted by hand.