### PR TITLE
Move the Stage and Verifier plugins to the retired manifest

### DIFF
--- a/aggregator/plugins/core/pom.xml
+++ b/aggregator/plugins/core/pom.xml
@@ -39,6 +39,5 @@ under the License.
     <module>../../../../plugins/core/maven-resources-plugin</module>
     <module>../../../../plugins/core/maven-site-plugin</module>
     <module>../../../../plugins/core/surefire</module>
-    <module>../../../../plugins/core/maven-verifier-plugin</module>
   </modules>
 </project>

--- a/aggregator/plugins/tools/pom.xml
+++ b/aggregator/plugins/tools/pom.xml
@@ -49,7 +49,6 @@ under the License.
     <module>../../../../plugins/tools/scm</module>
     <module>../../../../plugins/tools/maven-scm-publish-plugin</module>
     <module>../../../../plugins/tools/maven-scripting-plugin</module>
-    <module>../../../../plugins/tools/maven-stage-plugin</module>
     <module>../../../../plugins/tools/maven-toolchains-plugin</module>
   </modules>
 </project>

--- a/default.xml
+++ b/default.xml
@@ -45,7 +45,6 @@
   <project path='plugins/core/maven-resources-plugin'       name='maven-resources-plugin.git' revision="maven-resources-plugin-3.x" />
   <project path='plugins/core/maven-site-plugin'            name='maven-site-plugin.git' />
   <project path='plugins/core/surefire'                     name='maven-surefire.git' />
-  <project path='plugins/core/maven-verifier-plugin'        name='maven-verifier-plugin.git' />
 
   <project path='plugins/core-4/maven-clean-plugin'         name='maven-clean-plugin.git' />
   <project path='plugins/core-4/maven-compiler-plugin'      name='maven-compiler-plugin.git' />
@@ -94,7 +93,6 @@
   <project path='plugins/tools/scm'                         name='maven-scm.git' />
   <project path='plugins/tools/maven-scm-publish-plugin'    name='maven-scm-publish-plugin.git' />
   <project path='plugins/tools/maven-scripting-plugin'      name='maven-scripting-plugin.git' />
-  <project path='plugins/tools/maven-stage-plugin'          name='maven-stage-plugin.git' />
   <project path='plugins/tools/maven-toolchains-plugin'     name='maven-toolchains-plugin.git' />
 
   <project path='shared/archiver'                           name='maven-archiver.git' revision="maven-archiver-3.x" />

--- a/retired.xml
+++ b/retired.xml
@@ -24,12 +24,15 @@
   <remote name='svn2git' fetch='https://github.com/apache' />
   <default revision='master' remote='origin' sync-j='8' />
 
+  <project path='plugins/core/maven-verifier-plugin'        name='maven-verifier-plugin.git' />
+
   <project path='plugins/reporting/maven-docck-plugin'      name='maven-docck-plugin.git' />
 
   <project path='plugins/tools/maven-ant-plugin'            name='maven-ant-plugin.git' />
   <project path='plugins/tools/maven-patch-plugin'          name='maven-patch-plugin.git' />
   <project path='plugins/tools/maven-pdf-plugin'            name='maven-pdf-plugin.git' />
   <project path='plugins/tools/maven-repository-plugin'     name='maven-repository-plugin.git' />
+  <project path='plugins/tools/maven-stage-plugin'          name='maven-stage-plugin.git' />
 
   <project path='misc/skins/default'                        name='maven-default-skin.git' />
 


### PR DESCRIPTION
Manifest cleanup for the retirement of `maven-stage-plugin` and `maven-verifier-plugin`, voted through on 2025-11-29 — [[RESULT] [VOTE] Retire Maven Stage & Maven Verifier Plugins](https://lists.apache.org/thread/j0dqo61wlm7fxsrvgq0r718nzpjc1byk).

- `default.xml` → `retired.xml` for both projects
- the matching `<module>` dropped from `aggregator/plugins/tools/pom.xml` and `aggregator/plugins/core/pom.xml`

Both halves are needed: leaving a `<module>` behind breaks the aggregator build for everyone who syncs the manifest, because the checkout it points at is gone.

Companion PRs: apache/maven-stage-plugin#75 and apache/maven-verifier-plugin#67 (in-repo cleanup, must merge before INFRA archives the repos), apache/maven-site#1637 (index, scm.md and the PlantUML diagram).

<sub>Drafted with Claude — please verify</sub>