### PR TITLE
Correct the directory tree in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Resulting directory tree looks like:
 |   |-- executor
 |   |-- gh-actions-shared
 |   |   |-- main
-|   |   `-- v4
+|   |   `-- v5
 |   |-- indexer
 |   |-- jenkins
 |   |   |-- env
@@ -69,10 +69,8 @@ Resulting directory tree looks like:
 |   |   |-- languages
 |   |   |-- resources
 |   |   |-- sec-dispatcher
-|   |   |-- testing
 |   |   `-- velocity
 |   |-- modello
-|   |-- plexus-containers
 |   |-- pom
 |   |   `-- plexus
 |   |-- utils
@@ -86,7 +84,6 @@ Resulting directory tree looks like:
 |   |   |-- maven-install-plugin
 |   |   |-- maven-resources-plugin
 |   |   |-- maven-site-plugin
-|   |   |-- maven-verifier-plugin
 |   |   `-- surefire
 |   |-- core-4
 |   |   |-- maven-clean-plugin
@@ -133,7 +130,6 @@ Resulting directory tree looks like:
 |       |-- maven-remote-resources-plugin
 |       |-- maven-scm-publish-plugin
 |       |-- maven-scripting-plugin
-|       |-- maven-stage-plugin
 |       |-- maven-toolchains-plugin
 |       |-- plugin-tools
 |       |-- release


### PR DESCRIPTION
The tree drawn under "Resulting directory tree looks like" has drifted from `default.xml`. Five entries, each checked against the manifest:

| README says | manifest says |
| --- | --- |
| `misc/gh-actions-shared/v4` | `v5` |
| `plexus/components/testing` | `plexus/testing`, which the tree already lists separately |
| `plexus/plexus-containers` | gone |
| `plugins/core/maven-verifier-plugin` | gone |
| `plugins/tools/maven-stage-plugin` | gone |

Independent of #53, which adds `plexus-build-api` and its own tree line; the two touch different parts of the file.

Left as-is deliberately: the tree's ordering and its use of `` `-- `` for last children do not match what a mechanical render of `default.xml` would produce. Reformatting it wholesale would bury these five corrections in 150 lines of churn, and the file has no generator to keep it true afterwards.

*This change was created with AI assistance.*